### PR TITLE
Fix: set timeout outcome before erasing game on disconnect

### DIFF
--- a/src/sockets/chessSockets.ts
+++ b/src/sockets/chessSockets.ts
@@ -133,8 +133,15 @@ export function registerChessSockets(io: Server) {
                 }
                 // Set a 5-second timer to finalize disconnection if not reconnected
                 const timer = setTimeout(() => {
-                    gameManager.disconnect(userId);
+                    const timedOutGame = gameManager.disconnect(userId);
                     timerMap.delete(userId);
+                    if (timedOutGame) {
+                        const disconnectedColor = timedOutGame.players.white?.id === userId ? 'white' : 'black';
+                        const winnerColor = disconnectedColor === 'white' ? 'black' : 'white';
+                        timedOutGame.outcome = { winner: winnerColor, reason: 'timeout' };
+                        emitGame(io, timedOutGame);
+                        gameManager.eraseGame(timedOutGame);
+                    }
                     const games = gameManager.getAllGames();
                     io.emit('updateLobby', sanitizeGames(games));
                 }, 5000); // 5 seconds to reconnect


### PR DESCRIPTION
## Summary
- `Outcome` type declares `'timeout'` as a valid reason but it was never assigned
- When a player's 5-second reconnect timer expired, the game was silently erased with no outcome recorded
- Now sets `{ winner: <opponent>, reason: 'timeout' }` and emits the final game state before erasing

Closes #4